### PR TITLE
tmux 2.9

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -51,8 +51,8 @@ set -g status-left-length 52
 set -g status-right-length 451
 set -g status-fg white
 set -g status-bg colour234
-set -g pane-border-style colour245
-set -g pane-active-border-style colour39
+set -g pane-border-style fg=colour245
+set -g pane-active-border-style fg=colour39
 set -g message-style fg=colour16,bg=colour221,bold
 #set -g status-left '#[fg=colour235,bg=colour252,bold] ❐ #S #[fg=colour252,bg=colour238,nobold]⮀#[fg=colour245,bg=colour238,bold] #(whoami) #[fg=colour238,bg=colour234,nobold]⮀'
 # Status line with username:

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -51,11 +51,9 @@ set -g status-left-length 52
 set -g status-right-length 451
 set -g status-fg white
 set -g status-bg colour234
-set -g pane-border-fg colour245
-set -g pane-active-border-fg colour39
-set -g message-fg colour16
-set -g message-bg colour221
-set -g message-attr bold
+set -g pane-border-style colour245
+set -g pane-active-border-style colour39
+set -g message-style fg=colour16,bg=colour221,bold
 #set -g status-left '#[fg=colour235,bg=colour252,bold] ❐ #S #[fg=colour252,bg=colour238,nobold]⮀#[fg=colour245,bg=colour238,bold] #(whoami) #[fg=colour238,bg=colour234,nobold]⮀'
 # Status line with username:
 #set -g status-left '#[fg=colour235,bg=colour252,bold] ❐ #S #[fg=colour252,bg=colour238,nobold]#[fg=colour245,bg=colour238,bold] #(whoami) #[fg=colour238,bg=colour234,nobold]'


### PR DESCRIPTION
Changes to facilitate deprecated settings in tmux 2.9. The new ones also (seem to) work fine in older tmuxes, like 2.6.